### PR TITLE
Add jetton token operations example and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This library provides comprehensive Kotlin bindings that mimic the structure and
 - **🔒 Complete Crypto Support**: Native Ed25519 operations with BouncyCastle fallbacks
 - **🏗️ Smart Contract ABI**: Native ABI parsing, encoding, and decoding
 - **🌐 Multiple Transports**: Support for GraphQL, JSON-RPC, and Proto transports
+- **🪙 [Jetton API](src/main/kotlin/com/mazekine/nekoton/jetton)**: TIP3 token balance queries and transfers
 - **⚡ Modern Kotlin**: Built with Kotlin 2.0.21, leveraging coroutines, null safety, and data classes
 - **🛡️ Type Safety**: Comprehensive type definitions for all blockchain entities
 - **📚 Full Documentation**: Complete KDoc documentation with usage examples
@@ -305,7 +306,7 @@ See the [`examples/`](examples/) directory for comprehensive usage examples:
 - **[BasicWallet.kt](examples/BasicWallet.kt)** - Simple wallet operations
 - **[SmartContractInteraction.kt](examples/SmartContractInteraction.kt)** - Contract method calls
 - **[HDWallet.kt](examples/HDWallet.kt)** - Hierarchical deterministic wallets
-- **[TokenOperations.kt](examples/TokenOperations.kt)** - TIP3 token handling
+- **[TokenOperations.kt](examples/TokenOperations.kt)** - TIP3 token handling with [Jetton API](src/main/kotlin/com/mazekine/nekoton/jetton)
 - **[EventMonitoring.kt](examples/EventMonitoring.kt)** - Blockchain event monitoring
 
 ## Configuration

--- a/examples/EventMonitoring.kt
+++ b/examples/EventMonitoring.kt
@@ -1,0 +1,49 @@
+package examples
+
+import com.mazekine.nekoton.models.Address
+import com.mazekine.nekoton.transport.JrpcTransport
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.delay
+
+/**
+ * Example that demonstrates how to monitor blockchain events using flows.
+ *
+ * Subscribes to account state changes and new transactions for a given address
+ * and prints updates in real time.
+ */
+class EventMonitoring {
+    private val transport = JrpcTransport("https://rpc-testnet.tychoprotocol.com/proto")
+
+    fun monitor(address: String) = runBlocking {
+        val addr = Address(address)
+        println("Monitoring account: $addr")
+
+        // Subscribe to incoming transactions
+        val txJob = launch {
+            transport.subscribeToTransactions(addr).collect { tx ->
+                println("New transaction: ${'$'}{tx.id}")
+            }
+        }
+
+        // Subscribe to account state changes (e.g., balance updates)
+        val stateJob = launch {
+            transport.subscribeToAccountState(addr).collect { state ->
+                println("New balance: ${'$'}{state.balance?.toTokens() ?: "0"}")
+            }
+        }
+
+        // Monitor for 30 seconds
+        delay(30_000)
+        txJob.cancelAndJoin()
+        stateJob.cancelAndJoin()
+        transport.close()
+    }
+}
+
+fun main() {
+    val address = "0:0000000000000000000000000000000000000000000000000000000000000000"
+    EventMonitoring().monitor(address)
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,9 +6,8 @@ This directory contains practical examples demonstrating how to use Nekoton Kotl
 
 - [`BasicWallet.kt`](BasicWallet.kt) - Simple wallet operations (send/receive)
 - [`SmartContractInteraction.kt`](SmartContractInteraction.kt) - Calling smart contract methods
-- [`TokenOperations.kt`](TokenOperations.kt) - Working with TIP3 tokens
-- [`MultiSigWallet.kt`](MultiSigWallet.kt) - Multi-signature wallet operations
-- [`EventMonitoring.kt`](EventMonitoring.kt) - Monitoring blockchain events
+- [`TokenOperations.kt`](TokenOperations.kt) - Query jetton balances and transfer tokens using [Jetton API](../src/main/kotlin/com/mazekine/nekoton/jetton)
+- [`EventMonitoring.kt`](EventMonitoring.kt) - Monitor account state and transactions in real time
 - [`HDWallet.kt`](HDWallet.kt) - Hierarchical deterministic wallet
 
 ## Running Examples

--- a/examples/TokenOperations.kt
+++ b/examples/TokenOperations.kt
@@ -1,0 +1,47 @@
+package examples
+
+import com.mazekine.nekoton.models.Address
+import com.mazekine.nekoton.models.Tokens
+import com.mazekine.nekoton.transport.JrpcTransport
+import com.mazekine.nekoton.jetton.JettonApi
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Jetton token operations example.
+ *
+ * Demonstrates:
+ * - Querying jetton wallet balances
+ * - Transferring jettons using the Jetton API
+ */
+class TokenOperations {
+    private val transport = JrpcTransport("https://rpc-testnet.tychoprotocol.com/proto")
+    private val jettonApi = JettonApi(transport)
+
+    fun demonstrateTokenOperations() = runBlocking {
+        println("=== Jetton Token Operations ===")
+
+        // Replace with actual wallet address
+        val owner = Address("0:yourwalletaddress")
+
+        // Query jetton balance
+        val balance = jettonApi.getBalance(owner)
+        println("Jetton balance: ${balance.toTokens()} JETTON")
+
+        // Transfer jettons to another address
+        val recipient = Address("0:recipientaddress")
+        val amount = Tokens.fromTokens("1") // 1 token
+
+        val txHash = jettonApi.transfer(
+            from = owner,
+            to = recipient,
+            amount = amount
+        )
+        println("Transfer sent: $txHash")
+
+        transport.close()
+    }
+}
+
+fun main() {
+    TokenOperations().demonstrateTokenOperations()
+}


### PR DESCRIPTION
## Summary
- add TokenOperations example demonstrating jetton balance queries and transfers
- document Jetton API and restore EventMonitoring example in examples and top-level README

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b6f92386b4832d949847a6014ef9dc