### PR TITLE
Add documentation and Maven Central publish configuration

### DIFF
--- a/src/main/kotlin/com/mazekine/nekoton/jetton/JettonWallet.kt
+++ b/src/main/kotlin/com/mazekine/nekoton/jetton/JettonWallet.kt
@@ -45,6 +45,13 @@ class JettonWallet(val root: Address, val owner: Address, var balance: Long) {
     }
 }
 
+/**
+ * Represents normalized jetton wallet state returned by the native library or JSON parser.
+ *
+ * @property balance Jetton balance in smallest units
+ * @property owner Wallet owner's raw address string
+ * @property root Jetton root contract raw address string
+ */
 @Serializable
 data class JettonWalletState(
     val balance: Long,


### PR DESCRIPTION
## Summary
- document jetton wallet state model
- package sources and javadocs for Maven publication
- configure Maven Central publishing with signing

## Testing
- `./gradlew test -x buildRustLibrary -x copyNativeLibrary --rerun-tasks`


------
https://chatgpt.com/codex/tasks/task_e_68b7141feae4832d97df0bbe21ae8fbf