### PR TITLE
feat: add bundle task for Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,16 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ./gradlew buildRustLibrary build test
 ```
 
+### Maven Central Upload
+
+```bash
+# Build artifacts and create bundle for Sonatype's upload portal
+./gradlew createCentralBundle
+```
+
+The bundle will be available under `build/bundle` and contains the JAR, POM,
+sources, Javadoc and signature files in the required directory layout.
+
 ## License
 
 This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- create Gradle task to assemble signed Maven Central bundle with checksums
- document how to build the bundle via `createCentralBundle`

## Testing
- `./gradlew test`
- `./gradlew createCentralBundle` *(fails: gpg: signing failed: No secret key)*

------
https://chatgpt.com/codex/tasks/task_e_68b974590200832d9d299f7cc5ad1fe7