### PR TITLE
Bind native ABI handles and streamline encoding

### DIFF
--- a/src/main/kotlin/com/mazekine/nekoton/abi/ContractAbi.kt
+++ b/src/main/kotlin/com/mazekine/nekoton/abi/ContractAbi.kt
@@ -11,8 +11,6 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.decodeFromString
-import java.io.File
 
 /**
  * Represents a contract ABI (Application Binary Interface) for TON/Everscale smart contracts.
@@ -50,6 +48,9 @@ data class ContractAbi(
             try {
                 nativeHandle = Native.parseAbi(abiJson)
                 isNativeInitialized = nativeHandle != 0L
+                if (isNativeInitialized) {
+                    functions.values.forEach { it.bindNativeAbi(nativeHandle) }
+                }
             } catch (e: Exception) {
                 isNativeInitialized = false
             }
@@ -62,26 +63,10 @@ data class ContractAbi(
      * @param name The function name
      * @return FunctionAbi instance or null if not found
      */
-    fun getFunction(name: String): FunctionAbi? {
-        return if (isNativeInitialized) {
-            try {
-                val functionNamesBytes = Native.getAbiFunctionNames(nativeHandle)
-                val functionNamesJson = String(functionNamesBytes)
-                val functionNames = Json.decodeFromString<List<String>>(functionNamesJson)
-                
-                if (functionNames.contains(name)) {
-                    // For now, return the regular function ABI since NativeFunctionAbi doesn't extend FunctionAbi
-                    functions[name]
-                } else {
-                    null
-                }
-            } catch (e: Exception) {
-                functions[name]
-            }
-        } else {
-            functions[name]
+    fun getFunction(name: String): FunctionAbi? =
+        functions[name]?.also { fn ->
+            if (isNativeInitialized) fn.bindNativeAbi(nativeHandle)
         }
-    }
 
     /**
      * Gets an event ABI by name.

--- a/src/main/kotlin/com/mazekine/nekoton/abi/FunctionAbi.kt
+++ b/src/main/kotlin/com/mazekine/nekoton/abi/FunctionAbi.kt
@@ -56,6 +56,10 @@ data class FunctionAbi(
     @kotlinx.serialization.Transient
     private var nativeAbi: NativeFunctionAbi? = null
 
+    /** Helper to access bound native ABI or throw a consistent error. */
+    private fun requireNative(): NativeFunctionAbi =
+        nativeAbi ?: error("Native ABI is not bound. Call bindNativeAbi(parseAbi(json)) first.")
+
     /**
      * Attach a native ABI handle to this function. Safe to call once.
      */
@@ -118,16 +122,8 @@ data class FunctionAbi(
     ): UnsignedBody {
         val expireAt = nowSec() + (timeout ?: DEFAULT_TIMEOUT).toLong()
 
-        val payload: Cell = nativeAbi?.let { nat ->
-            // Delegate parameter packing (funcId + args) to native.
-            nat.encodeCall(input)
-        } ?: run {
-            // If native is unavailable, keep the previous Kotlin path or throw.
-            // Throwing is safer than producing malformed bodies.
-            throw UnsupportedOperationException(
-                "Native ABI is not bound. Call bindNativeAbi(parseAbi(json)) first."
-            )
-        }
+        // Delegate parameter packing (funcId + args) to native.
+        val payload: Cell = requireNative().encodeCall(input)
 
         val hash = payload.hash()
         return UnsignedBody(
@@ -172,10 +168,7 @@ data class FunctionAbi(
 
     /** Encode INTERNAL input body = (FunctionID + Enc(args)) using native when available. */
     fun encodeInternalInput(input: Map<String, Any>): Cell {
-        nativeAbi?.let { return it.encodeCall(input) }
-        throw UnsupportedOperationException(
-            "Native ABI is not bound. Call bindNativeAbi(parseAbi(json)) first."
-        )
+        return requireNative().encodeCall(input)
     }
 
     /** Try to decode a transaction’s inbound body assuming it targets this function. */
@@ -200,10 +193,7 @@ data class FunctionAbi(
      * Fully native path via Native.decodeFunctionOutput (JSON) -> Map<String, Any>.
      */
     fun decodeOutput(body: Cell, internal: Boolean = false): Map<String, Any> {
-        val nat = nativeAbi ?: throw UnsupportedOperationException(
-            "Native ABI is not bound. Call bindNativeAbi(parseAbi(json)) first."
-        )
-        val json = nat.decodeOutputJson(body)
+        val json = requireNative().decodeOutputJson(body)
         if (json.isEmpty()) return emptyMap()
         return json.mapValues { (_, v) -> jsonToKotlin(v) }
     }


### PR DESCRIPTION
## Summary
- attach native ABI handle to each function when parsing a ContractAbi
- centralize native access in FunctionAbi via `requireNative` helper
- delegate external/internal payload encoding and output decoding to JNI

## Testing
- `./gradlew test --no-daemon` *(fails: build terminated during native compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68bb3f3c9adc832da259886da5b35fce