### PR TITLE
Support ABI minor versions

### DIFF
--- a/examples/MultiSigWallet.kt
+++ b/examples/MultiSigWallet.kt
@@ -71,7 +71,7 @@ class MultiSigWallet {
         val payload = builder.build()
 
         return UnsignedBody(
-            abiVersion = AbiVersion(2),
+            abiVersion = AbiVersion(2, 3),
             payload = payload,
             hash = payload.hash(),
             expireAt = System.currentTimeMillis() / 1000 + 60

--- a/src/main/kotlin/com/mazekine/nekoton/abi/ContractAbi.kt
+++ b/src/main/kotlin/com/mazekine/nekoton/abi/ContractAbi.kt
@@ -261,10 +261,13 @@ data class ContractAbi(
         private fun parseAbiJson(abiJson: String): ContractAbi {
             val json = Json.parseToJsonElement(abiJson).jsonObject
             
-            // Parse ABI version
-            val abiVersion = json["ABI version"]?.let { 
-                AbiVersion(it.toString().toInt()) 
-            } ?: AbiVersion(1)
+            // Parse ABI version. Prefer full semantic version from `version` field,
+            // fall back to numeric `ABI version` if present.
+            val abiVersion = json["version"]?.jsonPrimitive?.content?.let {
+                AbiVersion.parse(it)
+            } ?: json["ABI version"]?.jsonPrimitive?.content?.let {
+                AbiVersion.parse(it)
+            } ?: AbiVersion(1, 0)
             
             // Parse functions
             val functions = mutableMapOf<String, FunctionAbi>()
@@ -572,16 +575,29 @@ data class ContractAbi(
 }
 
 /**
- * Represents an ABI version.
- * 
- * @property version The version number
+ * Represents an ABI version with major and minor components.
+ *
+ * Examples: 2.0, 2.1, 2.2, 2.3
  */
 @Serializable
-data class AbiVersion(val version: Int) {
-    /**
-     * Returns the version number as a string.
-     */
-    override fun toString(): String = version.toString()
+data class AbiVersion(val major: Int, val minor: Int = 0) {
+    override fun toString(): String = "$major.$minor"
+
+    companion object {
+        /** Predefined known versions */
+        val V2_0 = AbiVersion(2, 0)
+        val V2_1 = AbiVersion(2, 1)
+        val V2_2 = AbiVersion(2, 2)
+        val V2_3 = AbiVersion(2, 3)
+
+        /** Parses version strings like "2", "2.2", "2.3" */
+        fun parse(value: String): AbiVersion {
+            val parts = value.trim().split('.')
+            val major = parts.getOrNull(0)?.toIntOrNull() ?: 0
+            val minor = parts.getOrNull(1)?.toIntOrNull() ?: 0
+            return AbiVersion(major, minor)
+        }
+    }
 }
 
 /**

--- a/src/test/kotlin/com/mazekine/nekoton/abi/ContractAbiTest.kt
+++ b/src/test/kotlin/com/mazekine/nekoton/abi/ContractAbiTest.kt
@@ -22,7 +22,8 @@ class ContractAbiTest {
         val abi = ContractAbi(abiJson)
         
         assertNotNull(abi)
-        assertEquals(2, abi.abiVersion.version)
+        assertEquals(2, abi.abiVersion.major)
+        assertEquals(3, abi.abiVersion.minor)
         // Note: Function parsing not yet implemented
         assertNotNull(abi.functions)
         
@@ -38,7 +39,8 @@ class ContractAbiTest {
         val abi = ContractAbi(abiJson)
         
         assertNotNull(abi)
-        assertEquals(2, abi.abiVersion.version)
+        assertEquals(2, abi.abiVersion.major)
+        assertEquals(0, abi.abiVersion.minor)
         // Note: Function and event parsing not yet implemented
         assertNotNull(abi.functions)
         assertNotNull(abi.events)
@@ -57,7 +59,8 @@ class ContractAbiTest {
         val abi = ContractAbi(abiJson)
         
         assertNotNull(abi)
-        assertEquals(2, abi.abiVersion.version)
+        assertEquals(2, abi.abiVersion.major)
+        assertEquals(2, abi.abiVersion.minor)
         // Note: Function parsing not yet implemented
         assertNotNull(abi.functions)
         
@@ -122,7 +125,7 @@ class ContractAbiTest {
         val abi1 = ContractAbi(abiJson)
         val abi2 = ContractAbi(abiJson)
         
-        assertEquals(abi1.abiVersion.version, abi2.abiVersion.version)
+        assertEquals(abi1.abiVersion, abi2.abiVersion)
         assertEquals(abi1.functions.size, abi2.functions.size)
     }
     


### PR DESCRIPTION
## Summary
- Handle full ABI version string (e.g. 2.0, 2.1, 2.2, 2.3) when parsing ABI JSON
- Introduce `AbiVersion` with major/minor and predefined constants
- Adjust examples and tests to use semantic ABI versions

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68bfe815e9d8832db64976e54e16d5c1