### PR TITLE
Add OAuth well-known endpoints for MCP inspector

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,6 +79,7 @@ dependencies {
     implementation("io.ktor:ktor-client-content-negotiation:2.3.12")
     implementation("io.ktor:ktor-serialization-kotlinx-json:2.3.12")
     implementation("io.ktor:ktor-client-logging:2.3.12")
+    implementation("io.ktor:ktor-server-core-jvm:2.3.12")
 
     // Crypto libraries
     implementation("org.bouncycastle:bcprov-jdk18on:1.78.1")
@@ -97,6 +98,8 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.10.0")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
     testImplementation("io.mockk:mockk:1.13.12")
+    testImplementation("io.ktor:ktor-server-tests-jvm:2.3.12")
+    testImplementation("io.ktor:ktor-server-test-host-jvm:2.3.12")
 }
 
 // Add Rust compilation task

--- a/src/main/kotlin/com/mazekine/nekoton/oauth/McpOAuthConfig.kt
+++ b/src/main/kotlin/com/mazekine/nekoton/oauth/McpOAuthConfig.kt
@@ -1,0 +1,155 @@
+package com.mazekine.nekoton.oauth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Configuration describing how the MCP server exposes its OAuth 2.0/OpenID Connect metadata.
+ *
+ * The values provided here are rendered into the well-known discovery documents that
+ * OAuth clients (such as the MCP Inspector) expect when bootstrapping the authorization flow.
+ */
+data class McpOAuthConfig(
+    val issuer: String,
+    val authorizationEndpoint: String,
+    val tokenEndpoint: String,
+    val jwksUri: String? = null,
+    val userInfoEndpoint: String? = null,
+    val registrationEndpoint: String? = null,
+    val introspectionEndpoint: String? = null,
+    val revocationEndpoint: String? = null,
+    val deviceAuthorizationEndpoint: String? = null,
+    val scopes: List<String>,
+    val resourceScopes: List<String> = scopes,
+    val responseTypes: List<String> = listOf("code"),
+    val grantTypes: List<String> = listOf("authorization_code", "refresh_token"),
+    val tokenEndpointAuthMethods: List<String> = listOf("client_secret_basic"),
+    val codeChallengeMethods: List<String> = listOf("S256"),
+    val subjectTypes: List<String> = listOf("public"),
+    val idTokenSigningAlgs: List<String> = listOf("RS256"),
+    val claims: List<String> = emptyList(),
+    val authorizationServers: List<String> = listOf(issuer),
+    val protectedResourceId: String = "mcp",
+    val resourceType: String = "model-context-protocol",
+    val resourceDocumentation: String? = null,
+    val capabilities: Map<String, Boolean> = emptyMap(),
+) {
+    init {
+        require(scopes.isNotEmpty()) { "At least one OAuth scope must be supplied" }
+        require(resourceScopes.isNotEmpty()) { "At least one protected resource scope must be supplied" }
+        require(authorizationServers.isNotEmpty()) { "At least one authorization server identifier must be supplied" }
+    }
+
+    internal fun asAuthorizationServerMetadata() =
+        AuthorizationServerMetadata(
+            issuer = issuer,
+            authorizationEndpoint = authorizationEndpoint,
+            tokenEndpoint = tokenEndpoint,
+            jwksUri = jwksUri,
+            registrationEndpoint = registrationEndpoint,
+            deviceAuthorizationEndpoint = deviceAuthorizationEndpoint,
+            responseTypesSupported = responseTypes,
+            grantTypesSupported = grantTypes,
+            scopesSupported = scopes,
+            tokenEndpointAuthMethodsSupported = tokenEndpointAuthMethods,
+            codeChallengeMethodsSupported = codeChallengeMethods,
+            introspectionEndpoint = introspectionEndpoint,
+            revocationEndpoint = revocationEndpoint,
+            userInfoEndpoint = userInfoEndpoint,
+        )
+
+    internal fun asOpenIdConfiguration() =
+        OpenIdConfigurationMetadata(
+            issuer = issuer,
+            authorizationEndpoint = authorizationEndpoint,
+            tokenEndpoint = tokenEndpoint,
+            jwksUri = jwksUri,
+            userInfoEndpoint = userInfoEndpoint,
+            responseTypesSupported = responseTypes,
+            grantTypesSupported = grantTypes,
+            scopesSupported = scopes,
+            subjectTypesSupported = subjectTypes,
+            idTokenSigningAlgValuesSupported = idTokenSigningAlgs,
+            codeChallengeMethodsSupported = codeChallengeMethods,
+            tokenEndpointAuthMethodsSupported = tokenEndpointAuthMethods,
+            claimsSupported = claims,
+        )
+
+    internal fun asProtectedResourceMetadata() =
+        ProtectedResourceMetadata(
+            resource = protectedResourceId,
+            authorizationServers = authorizationServers,
+            scopesSupported = resourceScopes,
+            tokenEndpointAuthMethodsSupported = tokenEndpointAuthMethods,
+            resourceDocumentation = resourceDocumentation,
+        )
+
+    internal fun asMcpProtectedResourceMetadata() =
+        McpProtectedResourceMetadata(
+            resource = protectedResourceId,
+            resourceType = resourceType,
+            authorizationServers = authorizationServers,
+            scopesSupported = resourceScopes,
+            capabilities = capabilities,
+        )
+}
+
+/** OAuth 2.0 Authorization Server metadata as defined in RFC 8414. */
+@Serializable
+data class AuthorizationServerMetadata(
+    val issuer: String,
+    @SerialName("authorization_endpoint") val authorizationEndpoint: String,
+    @SerialName("token_endpoint") val tokenEndpoint: String,
+    @SerialName("jwks_uri") val jwksUri: String? = null,
+    @SerialName("registration_endpoint") val registrationEndpoint: String? = null,
+    @SerialName("device_authorization_endpoint") val deviceAuthorizationEndpoint: String? = null,
+    @SerialName("response_types_supported") val responseTypesSupported: List<String>,
+    @SerialName("grant_types_supported") val grantTypesSupported: List<String>,
+    @SerialName("scopes_supported") val scopesSupported: List<String>,
+    @SerialName("token_endpoint_auth_methods_supported") val tokenEndpointAuthMethodsSupported: List<String>,
+    @SerialName("code_challenge_methods_supported") val codeChallengeMethodsSupported: List<String>,
+    @SerialName("introspection_endpoint") val introspectionEndpoint: String? = null,
+    @SerialName("revocation_endpoint") val revocationEndpoint: String? = null,
+    @SerialName("userinfo_endpoint") val userInfoEndpoint: String? = null,
+)
+
+/** OpenID Provider metadata as defined in the OpenID Connect Discovery specification. */
+@Serializable
+data class OpenIdConfigurationMetadata(
+    val issuer: String,
+    @SerialName("authorization_endpoint") val authorizationEndpoint: String,
+    @SerialName("token_endpoint") val tokenEndpoint: String,
+    @SerialName("jwks_uri") val jwksUri: String? = null,
+    @SerialName("userinfo_endpoint") val userInfoEndpoint: String? = null,
+    @SerialName("response_types_supported") val responseTypesSupported: List<String>,
+    @SerialName("grant_types_supported") val grantTypesSupported: List<String>,
+    @SerialName("scopes_supported") val scopesSupported: List<String>,
+    @SerialName("subject_types_supported") val subjectTypesSupported: List<String>,
+    @SerialName("id_token_signing_alg_values_supported") val idTokenSigningAlgValuesSupported: List<String>,
+    @SerialName("code_challenge_methods_supported") val codeChallengeMethodsSupported: List<String>,
+    @SerialName("token_endpoint_auth_methods_supported") val tokenEndpointAuthMethodsSupported: List<String>,
+    @SerialName("claims_supported") val claimsSupported: List<String> = emptyList(),
+)
+
+/** Metadata describing a generic OAuth 2.0 protected resource (RFC 9470). */
+@Serializable
+data class ProtectedResourceMetadata(
+    val resource: String,
+    @SerialName("authorization_servers") val authorizationServers: List<String>,
+    @SerialName("scopes_supported") val scopesSupported: List<String>,
+    @SerialName("token_endpoint_auth_methods_supported")
+    val tokenEndpointAuthMethodsSupported: List<String>,
+    @SerialName("resource_documentation") val resourceDocumentation: String? = null,
+)
+
+/**
+ * Additional metadata for the MCP protected resource variant expected by the MCP Inspector.
+ */
+@Serializable
+data class McpProtectedResourceMetadata(
+    val resource: String,
+    @SerialName("resource_type") val resourceType: String,
+    @SerialName("authorization_servers") val authorizationServers: List<String>,
+    @SerialName("scopes_supported") val scopesSupported: List<String>,
+    val capabilities: Map<String, Boolean> = emptyMap(),
+)

--- a/src/main/kotlin/com/mazekine/nekoton/oauth/McpOAuthRoutes.kt
+++ b/src/main/kotlin/com/mazekine/nekoton/oauth/McpOAuthRoutes.kt
@@ -1,0 +1,77 @@
+package com.mazekine.nekoton.oauth
+
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.Application
+import io.ktor.server.application.ApplicationCall
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.options
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+private val metadataJson = Json { encodeDefaults = true }
+
+/**
+ * Installs well-known OAuth/OpenID discovery endpoints required by the MCP Inspector.
+ *
+ * The generated endpoints answer:
+ * - /.well-known/oauth-authorization-server
+ * - /.well-known/openid-configuration
+ * - /.well-known/oauth-protected-resource
+ * - /.well-known/oauth-protected-resource/mcp
+ */
+fun Application.configureMcpOAuthWellKnown(config: McpOAuthConfig) {
+    routing {
+        route("/.well-known") {
+            wellKnownEndpoint("oauth-authorization-server") { config.asAuthorizationServerMetadata() }
+            wellKnownEndpoint("openid-configuration") { config.asOpenIdConfiguration() }
+            wellKnownEndpoint("oauth-protected-resource") { config.asProtectedResourceMetadata() }
+            wellKnownEndpoint("oauth-protected-resource/mcp") { config.asMcpProtectedResourceMetadata() }
+        }
+    }
+}
+
+private inline fun <reified T> Route.wellKnownEndpoint(
+    path: String,
+    crossinline payloadProvider: () -> T,
+) {
+    route(path) {
+        options {
+            call.applyCorsHeaders()
+            call.respond(HttpStatusCode.NoContent)
+        }
+        get {
+            call.applyCorsHeaders()
+            val payload = payloadProvider()
+            call.respondText(metadataJson.encodeToString(payload), ContentType.Application.Json)
+        }
+    }
+}
+
+private fun ApplicationCall.applyCorsHeaders() {
+    val origin = request.headers[HttpHeaders.Origin]
+    if (origin != null) {
+        response.headers.append(HttpHeaders.AccessControlAllowOrigin, origin, false)
+        response.headers.append(HttpHeaders.Vary, HttpHeaders.Origin, false)
+        response.headers.append(HttpHeaders.AccessControlAllowCredentials, "true", false)
+    } else {
+        response.headers.append(HttpHeaders.AccessControlAllowOrigin, "*", false)
+    }
+
+    response.headers.append(HttpHeaders.AccessControlAllowMethods, "GET, ${HttpMethod.Options.value}", false)
+
+    val requestedHeaders = request.headers[HttpHeaders.AccessControlRequestHeaders]
+    if (!requestedHeaders.isNullOrBlank()) {
+        response.headers.append(HttpHeaders.AccessControlAllowHeaders, requestedHeaders, false)
+    } else {
+        response.headers.append(HttpHeaders.AccessControlAllowHeaders, "Authorization, Content-Type", false)
+    }
+}

--- a/src/test/kotlin/com/mazekine/nekoton/oauth/McpOAuthRoutesTest.kt
+++ b/src/test/kotlin/com/mazekine/nekoton/oauth/McpOAuthRoutesTest.kt
@@ -1,0 +1,125 @@
+package com.mazekine.nekoton.oauth
+
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.request
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+
+class McpOAuthRoutesTest {
+    private val json = Json { ignoreUnknownKeys = false }
+
+    private val config =
+        McpOAuthConfig(
+            issuer = "https://auth.example.com",
+            authorizationEndpoint = "https://auth.example.com/oauth/authorize",
+            tokenEndpoint = "https://auth.example.com/oauth/token",
+            jwksUri = "https://auth.example.com/.well-known/jwks.json",
+            userInfoEndpoint = "https://auth.example.com/userinfo",
+            registrationEndpoint = "https://auth.example.com/register",
+            introspectionEndpoint = "https://auth.example.com/introspect",
+            revocationEndpoint = "https://auth.example.com/revoke",
+            deviceAuthorizationEndpoint = "https://auth.example.com/device",
+            scopes = listOf("mcp:read", "mcp:write"),
+            resourceScopes = listOf("mcp:read"),
+            responseTypes = listOf("code"),
+            grantTypes = listOf("authorization_code", "refresh_token"),
+            tokenEndpointAuthMethods = listOf("client_secret_post"),
+            codeChallengeMethods = listOf("S256"),
+            subjectTypes = listOf("public"),
+            idTokenSigningAlgs = listOf("RS256"),
+            claims = listOf("sub", "email"),
+            authorizationServers = listOf("https://auth.example.com"),
+            protectedResourceId = "https://api.example.com/mcp",
+            resourceType = "model-context-protocol",
+            resourceDocumentation = "https://docs.example.com/mcp",
+            capabilities = mapOf("supports_sessions" to true, "requires_scopes" to true),
+        )
+
+    @Test
+    fun `authorization server metadata is exposed`() = testApplication {
+        application { configureMcpOAuthWellKnown(config) }
+
+        val response =
+            client.get("/.well-known/oauth-authorization-server") {
+                header(HttpHeaders.Origin, "https://mcp.inspector")
+            }
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        val contentType = response.headers[HttpHeaders.ContentType]
+        assertNotNull(contentType)
+        assertTrue(contentType.startsWith(ContentType.Application.Json.toString()))
+        assertEquals("https://mcp.inspector", response.headers[HttpHeaders.AccessControlAllowOrigin])
+
+        val payload = json.decodeFromString<AuthorizationServerMetadata>(response.bodyAsText())
+        assertEquals(config.issuer, payload.issuer)
+        assertEquals(config.authorizationEndpoint, payload.authorizationEndpoint)
+        assertEquals(config.tokenEndpoint, payload.tokenEndpoint)
+        assertEquals(config.scopes, payload.scopesSupported)
+        assertEquals(config.grantTypes, payload.grantTypesSupported)
+        assertEquals(config.codeChallengeMethods, payload.codeChallengeMethodsSupported)
+    }
+
+    @Test
+    fun `openid discovery metadata mirrors the authorization metadata`() = testApplication {
+        application { configureMcpOAuthWellKnown(config) }
+
+        val response = client.get("/.well-known/openid-configuration")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("*", response.headers[HttpHeaders.AccessControlAllowOrigin])
+
+        val payload = json.decodeFromString<OpenIdConfigurationMetadata>(response.bodyAsText())
+        assertEquals(config.issuer, payload.issuer)
+        assertEquals(config.authorizationEndpoint, payload.authorizationEndpoint)
+        assertEquals(config.tokenEndpoint, payload.tokenEndpoint)
+        assertEquals(config.subjectTypes, payload.subjectTypesSupported)
+        assertEquals(config.idTokenSigningAlgs, payload.idTokenSigningAlgValuesSupported)
+        assertEquals(config.tokenEndpointAuthMethods, payload.tokenEndpointAuthMethodsSupported)
+    }
+
+    @Test
+    fun `preflight requests are permitted`() = testApplication {
+        application { configureMcpOAuthWellKnown(config) }
+
+        val response =
+            client.request("/.well-known/oauth-protected-resource/mcp") {
+                method = HttpMethod.Options
+                header(HttpHeaders.Origin, "https://tooling.example")
+                header(HttpHeaders.AccessControlRequestHeaders, "authorization,content-type")
+            }
+
+        assertEquals(HttpStatusCode.NoContent, response.status)
+        assertEquals("https://tooling.example", response.headers[HttpHeaders.AccessControlAllowOrigin])
+        assertEquals("GET, OPTIONS", response.headers[HttpHeaders.AccessControlAllowMethods])
+        val allowedHeaders = response.headers[HttpHeaders.AccessControlAllowHeaders]
+        assertNotNull(allowedHeaders)
+        assertTrue(allowedHeaders.contains("authorization", ignoreCase = true))
+        assertTrue(allowedHeaders.contains("content-type", ignoreCase = true))
+    }
+
+    @Test
+    fun `mcp protected resource metadata exposes capabilities`() = testApplication {
+        application { configureMcpOAuthWellKnown(config) }
+
+        val response = client.get("/.well-known/oauth-protected-resource/mcp")
+
+        assertEquals(HttpStatusCode.OK, response.status)
+
+        val payload = json.decodeFromString<McpProtectedResourceMetadata>(response.bodyAsText())
+        assertEquals(config.protectedResourceId, payload.resource)
+        assertEquals(config.authorizationServers, payload.authorizationServers)
+        assertEquals(config.resourceScopes, payload.scopesSupported)
+        assertEquals(config.capabilities, payload.capabilities)
+    }
+}


### PR DESCRIPTION
## Summary
- add an OAuth/OpenID configuration model for serving MCP discovery metadata
- expose Ktor routes that return the expected /.well-known JSON documents with CORS headers
- cover the new endpoints with tests that validate GET and OPTIONS behaviour

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d1349734d0832d91e6fcc5a2cb1436