### PR TITLE
Implement EventAbi parameter decoding logic

### DIFF
--- a/src/main/kotlin/com/mazekine/nekoton/abi/ContractAbi.kt
+++ b/src/main/kotlin/com/mazekine/nekoton/abi/ContractAbi.kt
@@ -222,8 +222,8 @@ data class ContractAbi(
      * @param transaction The transaction to decode
      * @return List of decoded events
      */
-    fun decodeTransactionEvents(transaction: Transaction): List<Pair<EventAbi, Map<String, Any>>> {
-        val decodedEvents = mutableListOf<Pair<EventAbi, Map<String, Any>>>()
+    fun decodeTransactionEvents(transaction: Transaction): List<Pair<EventAbi, Map<String, Any?>>> {
+        val decodedEvents = mutableListOf<Pair<EventAbi, Map<String, Any?>>>()
         
         for (outMsg in transaction.outMsgs) {
             if (!outMsg.isExternalOut()) continue

--- a/src/main/kotlin/com/mazekine/nekoton/abi/EventAbi.kt
+++ b/src/main/kotlin/com/mazekine/nekoton/abi/EventAbi.kt
@@ -1,9 +1,12 @@
 package com.mazekine.nekoton.abi
 
 import com.mazekine.nekoton.abi.param.AbiParam
+import com.mazekine.nekoton.abi.param.AbiParamType
+import com.mazekine.nekoton.abi.param.AbiTypeUtils
 import com.mazekine.nekoton.models.Cell
 import com.mazekine.nekoton.models.CellSlice
 import com.mazekine.nekoton.models.Message
+import com.mazekine.nekoton.models.Tokens
 import kotlinx.serialization.Serializable
 
 /**
@@ -32,7 +35,7 @@ data class EventAbi(
      * @return Decoded event parameters
      * @throws IllegalArgumentException if the message doesn't contain this event
      */
-    fun decodeMessage(message: Message): Map<String, Any> {
+    fun decodeMessage(message: Message): Map<String, Any?> {
         val body = message.body ?: throw IllegalArgumentException("Message has no body")
         return decodeMessageBody(body)
     }
@@ -44,19 +47,19 @@ data class EventAbi(
      * @return Decoded event parameters
      * @throws IllegalArgumentException if the body doesn't contain this event
      */
-    fun decodeMessageBody(body: Cell): Map<String, Any> {
+    fun decodeMessageBody(body: Cell): Map<String, Any?> {
         val slice = body.beginParse()
-        
+
         // Read and verify event ID
         val eventId = slice.readUint(32).intValue()
         require(eventId == id) { "Event ID mismatch: expected $id, got $eventId" }
         
         // Decode event parameters
-        val decodedParams = mutableMapOf<String, Any>()
+        val decodedParams = mutableMapOf<String, Any?>()
         for (param in inputs) {
             decodedParams[param.name] = decodeParam(slice, param)
         }
-        
+
         return decodedParams
     }
 
@@ -66,8 +69,8 @@ data class EventAbi(
      * @param slice The cell slice to read from
      * @return Decoded event parameters
      */
-    fun decodeInput(slice: CellSlice): Map<String, Any> {
-        val decodedParams = mutableMapOf<String, Any>()
+    fun decodeInput(slice: CellSlice): Map<String, Any?> {
+        val decodedParams = mutableMapOf<String, Any?>()
         for (param in inputs) {
             decodedParams[param.name] = decodeParam(slice, param)
         }
@@ -100,9 +103,68 @@ data class EventAbi(
         /**
          * Decodes a parameter value from a cell slice.
          */
-        private fun decodeParam(slice: CellSlice, param: AbiParam): Any {
-            // This would require the actual parameter decoding logic
-            TODO("Parameter decoding not yet implemented")
+        private fun decodeParam(slice: CellSlice, param: AbiParam): Any? {
+            val type = AbiParamType.fromString(param.type)
+            return when (type) {
+                AbiParamType.UINT -> {
+                    val bits = AbiTypeUtils.getIntegerBitSize(param.type)
+                    slice.readUint(bits)
+                }
+                AbiParamType.INT -> {
+                    val bits = AbiTypeUtils.getIntegerBitSize(param.type)
+                    slice.readInt(bits)
+                }
+                AbiParamType.BOOL -> slice.readBit()
+                AbiParamType.BYTES -> {
+                    val len = slice.readUint(32).intValue()
+                    slice.readBytes(len)
+                }
+                AbiParamType.BYTES_FIXED -> {
+                    val size = AbiTypeUtils.getFixedBytesSize(param.type)
+                    slice.readBytes(size)
+                }
+                AbiParamType.STRING -> {
+                    val len = slice.readUint(32).intValue()
+                    String(slice.readBytes(len))
+                }
+                AbiParamType.ADDRESS -> slice.readAddress()
+                AbiParamType.CELL -> slice.readRef()
+                AbiParamType.GRAMS -> Tokens(slice.readVarUint(4))
+                AbiParamType.TUPLE -> {
+                    val map = mutableMapOf<String, Any?>()
+                    param.components?.forEach { comp ->
+                        map[comp.name] = decodeParam(slice, comp)
+                    }
+                    map
+                }
+                AbiParamType.ARRAY -> {
+                    val length = slice.readUint(32).intValue()
+                    val list = mutableListOf<Any?>()
+                    val component = param.components?.firstOrNull() ?: AbiParam(param.name, param.getBaseType())
+                    repeat(length) { list.add(decodeParam(slice, component)) }
+                    list
+                }
+                AbiParamType.OPTIONAL -> {
+                    val has = slice.readBit()
+                    if (!has) null else {
+                        val innerType = AbiParam(param.name, AbiTypeUtils.parseOptionalType(param.type), param.components)
+                        decodeParam(slice, innerType)
+                    }
+                }
+                AbiParamType.MAP -> {
+                    val size = slice.readUint(32).intValue()
+                    val result = mutableMapOf<Any?, Any?>()
+                    val (keyType, valueType) = AbiTypeUtils.parseMapType(param.type)
+                    val keyParam = AbiParam("key", keyType)
+                    val valueParam = AbiParam("value", valueType)
+                    repeat(size) {
+                        val key = decodeParam(slice, keyParam)
+                        val value = decodeParam(slice, valueParam)
+                        result[key] = value
+                    }
+                    result
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement decoding for EventAbi parameters covering primitive, tuple, array, optional, and map ABI types
- expose nullable event parameter maps and update ContractAbi transaction event decoding to match the new signature

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68e3b1c58234832d8ffa32a388d1442f